### PR TITLE
Fix Electrum locale download URL

### DIFF
--- a/contrib/make_locale
+++ b/contrib/make_locale
@@ -43,7 +43,7 @@ if crowdin_api_key:
 
 # Download & unzip
 print('Download translations')
-s = requests.request('GET', 'https://crowdin.com/download/project/' + crowdin_identifier + '.zip').content
+s = requests.request('GET', 'https://crowdin.com/backend/download/project/' + crowdin_identifier + '.zip').content
 zfobj = zipfile.ZipFile(io.BytesIO(s))
 
 print('Unzip translations')


### PR DESCRIPTION
The CDN has changed their URL.
See https://github.com/spesmilo/electrum/issues/4559